### PR TITLE
Add Porto Velho SEO references

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Daniele Nicolini | Desenvolvedor de Sistemas PHP e Laravel</title>
-    <meta name="description" content="Portfólio de Daniele Nicolini, desenvolvedor de sistemas especializado em PHP e Laravel." />
-    <meta name="keywords" content="daniele, nicolini, php, laravel, desenvolvedor de sistemas, desenvolvimento back-end" />
+    <meta name="description" content="Portfólio de Daniele Nicolini, desenvolvedor de sistemas especializado em PHP e Laravel em Porto Velho, Rondônia." />
+    <meta name="keywords" content="daniele, nicolini, php, laravel, desenvolvedor de sistemas, desenvolvimento back-end, Porto Velho, desenvolvedor Porto Velho, criador de sistemas Porto Velho, desenvolvedor de sistemas em Porto Velho" />
     <meta name="author" content="Daniele Nicolini" />
     <meta http-equiv="Content-Language" content="pt-br" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://nicolini.tech" />
     <meta property="og:title" content="Daniele Nicolini - Desenvolvedor de Sistemas PHP e Laravel" />
-    <meta property="og:description" content="Portfólio de Daniele Nicolini, desenvolvedor de sistemas especializado em PHP e Laravel." />
+    <meta property="og:description" content="Portfólio de Daniele Nicolini, desenvolvedor de sistemas especializado em PHP e Laravel em Porto Velho, Rondônia." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://nicolini.tech" />
     <meta property="og:locale" content="pt_BR" />
@@ -31,13 +31,13 @@
     "knowsAbout": ["PHP", "Laravel", "Vue.js", "React", "JavaScript", "Docker", "APIs REST", "MySQL", "MongoDB", "Tailwind", "WordPress", "Git", "Desenvolvimento Web", "Backend"]
     }
     </script>
-    <meta name="description" content="Portfólio de Daniele Nicolini, desenvolvedora de sistemas full stack com foco em back-end, especializada em PHP, Laravel, Vue.js, React e APIs modernas." />
-    <meta name="keywords" content="Daniele Nicolini, desenvolvedora de sistemas, desenvolvedora back-end, desenvolvedora PHP, desenvolvedora Laravel, desenvolvedora full stack, freelancer PHP, React, Vue, Tailwind, API REST, GitHub, Git, MySQL, MongoDB, desenvolvimento web" />
+    <meta name="description" content="Portfólio de Daniele Nicolini, desenvolvedora de sistemas full stack com foco em back-end em Porto Velho, Rondônia, especializada em PHP, Laravel, Vue.js, React e APIs modernas." />
+    <meta name="keywords" content="Daniele Nicolini, desenvolvedora de sistemas, desenvolvedora back-end, desenvolvedora PHP, desenvolvedora Laravel, desenvolvedora full stack, freelancer PHP, React, Vue, Tailwind, API REST, GitHub, Git, MySQL, MongoDB, desenvolvimento web, Porto Velho, Rondônia, desenvolvedora em Porto Velho, criador de sistemas em Porto Velho, desenvolvimento de sistemas Porto Velho" />
     <meta property="og:title" content="Daniele Nicolini - Desenvolvedora de Sistemas | PHP, Laravel, React, Vue.js" />
     <meta property="og:description" content="Desenvolvedora Full Stack com foco em back-end. Experiência sólida com Laravel, Vue.js, React, e bancos de dados relacionais e não relacionais." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Daniele Nicolini | Desenvolvedora PHP, Laravel, React" />
-    <meta name="twitter:description" content="Desenvolvedora de sistemas com foco em soluções modernas, APIs REST e plataformas escaláveis." />
+    <meta name="twitter:description" content="Desenvolvedora de sistemas com foco em soluções modernas, APIs REST e plataformas escaláveis em Porto Velho, Rondônia." />
 
 
 
@@ -117,9 +117,10 @@
 <h1 class="sr-only">Desenvolvedora PHP e Laravel, Full Stack, Especialista em APIs REST</h1>
 <h2 class="sr-only">Portfólio de Daniele Nicolini | Freelancer em React, Vue.js, Docker, MySQL</h2>
 <h3 class="sr-only">Desenvolvimento de Sistemas Web com Foco em Back-end, Front-end e Integrações</h3>
+<h4 class="sr-only">Desenvolvedora de Sistemas em Porto Velho, Rondônia</h4>
 
 <div style="display:none;">
-  Desenvolvedora de software, sistemas empresariais, soluções em nuvem, Node.js, SaaS, DevOps, PostgreSQL, Typescript, test driven development, CI/CD, versionamento com Git.
+  Desenvolvedora de software, sistemas empresariais, soluções em nuvem, Node.js, SaaS, DevOps, PostgreSQL, Typescript, test driven development, CI/CD, versionamento com Git, Porto Velho, Rondônia, desenvolvedor de sistemas Porto Velho, criador de sistemas Porto Velho, desenvolvimento web em Porto Velho.
 </div>
 
     <section


### PR DESCRIPTION
## Summary
- target Porto Velho keywords for more localized SEO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cb60a6a8483269110c3caefb243c3